### PR TITLE
disable wheel events on number inputs

### DIFF
--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -1,3 +1,4 @@
+import { mergeRefs } from 'react-merge-refs';
 import * as React from 'react';
 
 import { cn } from '~/utils';
@@ -8,6 +9,26 @@ export interface InputProps
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
 	({ className, type = 'text', ...props }, ref) => {
+		const inputRef = React.useRef<HTMLInputElement>();
+
+		// Disable wheel event from triggering step change on input
+		React.useEffect(() => {
+			if (type !== 'number') {
+				return;
+			}
+			const { current: input } = inputRef;
+
+			const handleWheel = (ev: Event) => {
+				if ((ev as WheelEvent).deltaY && document.activeElement === input) {
+					ev.preventDefault();
+				}
+			};
+
+			input?.addEventListener('wheel', handleWheel);
+
+			return () => input?.removeEventListener('wheel', handleWheel);
+		}, [type]);
+
 		return (
 			<input
 				type={type}
@@ -15,7 +36,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 					'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-[invalid]:border-red-600',
 					className,
 				)}
-				ref={ref}
+				ref={mergeRefs([ref, inputRef])}
 				{...props}
 			/>
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-aria": "^3.31.1",
         "react-day-picker": "^8.10.0",
         "react-dom": "^18.2.0",
+        "react-merge-refs": "^2.1.1",
         "react-resizable-panels": "^1.0.9",
         "react-stately": "^3.29.1",
         "remix-themes": "^1.2.2",
@@ -16148,6 +16149,15 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-merge-refs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.1.1.tgz",
+      "integrity": "sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-aria": "^3.31.1",
     "react-day-picker": "^8.10.0",
     "react-dom": "^18.2.0",
+    "react-merge-refs": "^2.1.1",
     "react-resizable-panels": "^1.0.9",
     "react-stately": "^3.29.1",
     "remix-themes": "^1.2.2",


### PR DESCRIPTION
Number inputs change value when a wheel event is detected and the cursor is above the input. this is kindof annoying when trying to scroll a page, and leads to a lot of inadvertent changes to the inputs. Completely disabling the wheel events is probably not the greatest thing to do, but it does fix this UX annoyance. 