### PR TITLE
use real data for fairways hit dashboard card

### DIFF
--- a/app/api/round.server.ts
+++ b/app/api/round.server.ts
@@ -1,4 +1,4 @@
-import { Prisma, type HoleStats, type Round, type User } from '@prisma/client';
+import { type HoleStats, type Round, type User } from '@prisma/client';
 
 import { prisma } from '~/db.server';
 

--- a/app/routes/_index/dashboard.tsx
+++ b/app/routes/_index/dashboard.tsx
@@ -26,8 +26,6 @@ export function Dashboard() {
 	const { rounds, roundsPlayedTrend, fairwaysHitTrend } =
 		useLoaderData<Loader>();
 
-	console.log({ fairwaysHitTrend });
-
 	return (
 		<main>
 			<PageHeader

--- a/app/routes/_index/dashboard.tsx
+++ b/app/routes/_index/dashboard.tsx
@@ -23,7 +23,10 @@ import { calculateScoreDifferential, cn, formatDate } from '~/utils';
 import { type Loader } from './route';
 
 export function Dashboard() {
-	const { rounds, roundsPlayedTrend } = useLoaderData<Loader>();
+	const { rounds, roundsPlayedTrend, fairwaysHitTrend } =
+		useLoaderData<Loader>();
+
+	console.log({ fairwaysHitTrend });
 
 	return (
 		<main>
@@ -46,9 +49,9 @@ export function Dashboard() {
 
 				<QuickStat
 					title="Fairways Hit"
-					stat="68%"
-					trend="+6% since last month"
-					trendDirection="positive"
+					stat={`${formatPercent(fairwaysHitTrend.currentPercent)}`}
+					trend={getPercentageDiffText(fairwaysHitTrend.diff)}
+					trendDirection={getTrendDirection(fairwaysHitTrend.diff)}
 				/>
 				<QuickStat
 					title="Rounds Played"
@@ -143,6 +146,28 @@ const QuickStat = ({ title, stat, trend, trendDirection }: QuickStatProps) => {
 			</CardContent>
 		</Card>
 	);
+};
+
+const formatPercent = (percentage: number) => {
+	return new Intl.NumberFormat('en-US', {
+		style: 'percent',
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	}).format(percentage);
+};
+
+const getPercentageDiffText = (percentage: number) => {
+	if (percentage === 0) {
+		return 'Same as last month';
+	}
+	let symbol = '';
+	if (percentage > 0) {
+		symbol = '+';
+	}
+	if (percentage < 0) {
+		symbol = '-';
+	}
+	return `${symbol}${formatPercent(percentage)} since last month`;
 };
 
 const getRoundsPlayedTrendText = (value: number) => {

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,7 +1,11 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { type MetaFunction } from '@remix-run/react';
 
-import { getCompletedRounds, getRoundsPlayedMonthTrend } from '~/api/round.server';
+import {
+	getCompletedRounds,
+	getFairwaysHitTrend,
+	getRoundsPlayedMonthTrend,
+} from '~/api/round.server';
 import { requireUserId } from '~/session.server';
 import { Dashboard } from './dashboard';
 
@@ -10,9 +14,19 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 	const rounds = await getCompletedRounds({ userId, take: 5 });
 
 	const date = new Date();
-	const roundsPlayedTrend = await getRoundsPlayedMonthTrend({userId, month: date.getMonth(), year: date.getFullYear()})
+	const roundsPlayedTrend = await getRoundsPlayedMonthTrend({
+		userId,
+		month: date.getMonth(),
+		year: date.getFullYear(),
+	});
 
-	return json({ rounds, roundsPlayedTrend });
+	const fairwaysHitTrend = await getFairwaysHitTrend({
+		userId,
+		month: date.getMonth(),
+		year: date.getFullYear(),
+	});
+
+	return json({ rounds, roundsPlayedTrend, fairwaysHitTrend });
 };
 
 export type Loader = typeof loader;


### PR DESCRIPTION
sets up the dashboard to use actual data fro the `Fairways Hit` card. Kind of wild prisma queries were needed to avoid having to do a bunch of post-processing of the data, but its fine for now.